### PR TITLE
修改路径

### DIFF
--- a/archive/jd_getShareCodes.ts
+++ b/archive/jd_getShareCodes.ts
@@ -2,8 +2,8 @@
  * cron: 59 23 * * 0
  */
 
-import {getCookie, wait} from "../TS_USER_AGENTS";
-import {bean, farm, pet, factory, sgmh, jxfactory, health} from "../utils/shareCodesTool";
+import {getCookie, wait} from "./TS_USER_AGENTS";
+import {bean, farm, pet, factory, sgmh, jxfactory, health} from "./utils/shareCodesTool";
 
 let cookie: string = '', UserName: string, index: number
 let beans: string = '', farms: string = '', healths: string = '', pets: string = '', factorys: string = '', jxfactorys: string = '', sgmhs: string = '', s: string = '';


### PR DESCRIPTION
青龙不会把archive文件夹下的脚本放在archive文件夹里\qinglong\scripts\JDHelloWorld_jd_scripts\archive文件夹下，而是放在qinglong\scripts\JDHelloWorld_jd_scripts文件夹下，和TS_USER_AGENTS.ts、/utils/shareCodesTool在同一个文件夹下